### PR TITLE
github ci: add arm v6 docker image builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build and push to GitHub Container Registry
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
This commit adds support for building ARM v6 images along with the other architectures, this is useful for old Raspberry Pi's and Pi Zeros.