### PR TITLE
Experimenting with interface to enable/disable charger

### DIFF
--- a/mk2core/core.go
+++ b/mk2core/core.go
@@ -52,6 +52,12 @@ func (s *subscription) C() chan *mk2driver.Mk2Info {
 	return s.send
 }
 
+
+func (s *subscription) SendCommand(data []byte) {
+
+}
+
+
 func (s *subscription) Close() {
 	close(s.send)
 }

--- a/mk2driver/mk2.go
+++ b/mk2driver/mk2.go
@@ -413,7 +413,15 @@ func getLEDs(ledsOn, ledsBlink byte) map[Led]LEDstate {
 	return leds
 }
 
+
 // Adds header and trailing crc for frame to send.
+// CHARGER ON
+//  07 ff  58 37 01 00 14 81  d5
+//  07 ff  5a 37 01 00 14 81  d3
+
+// CHARGER OFF
+//  07 ff  5a 37 01 00 54 81  93
+//  07 ff  59 37 01 00 54 81  94
 func (m *mk2Ser) sendCommand(data []byte) {
 	l := len(data)
 	dataOut := make([]byte, l+3)
@@ -431,6 +439,10 @@ func (m *mk2Ser) sendCommand(data []byte) {
 	if err != nil {
 		m.addError(fmt.Errorf("Write error: %v", err))
 	}
+}
+
+func (m *mk2Ser) SendCommand(data []byte) {
+	m.sendCommand(data)
 }
 
 // Checks the frame crc.

--- a/mk2driver/mk2interface.go
+++ b/mk2driver/mk2interface.go
@@ -75,4 +75,5 @@ type Mk2Info struct {
 type Mk2 interface {
 	C() chan *Mk2Info
 	Close()
+	SendCommand(data []byte)
 }

--- a/mk2driver/mockmk2.go
+++ b/mk2driver/mockmk2.go
@@ -37,6 +37,10 @@ func (m *mock) Close() {
 
 }
 
+func (m *mock) SendCommand(data []byte) {
+
+}
+
 func (m *mock) genMockValues() {
 	mult := 1.0
 	ledState := LedOff


### PR DESCRIPTION
Not meant to be merged in this fashion. More of a PoC of what I am thinking of.

I am `ptracing` the `victron-connect` utility to get the payload to enable/disable the charger.

Interestingly enough both work identically:
`0x58, 0x37, 0x01, 0x00, <0x14 for on, 0x54 for off>, 0x81`
`0x5a, 0x37, 0x01, 0x00, <0x14 for on, 0x54 for off>, 0x81`

Anyone has documentation on the protocol beyond the CRC and the frameHeader and size prefix?